### PR TITLE
Update ArtGallery.sol: Improving Gas Optimizations

### DIFF
--- a/contracts/ArtGallery.sol
+++ b/contracts/ArtGallery.sol
@@ -18,8 +18,8 @@ contract ArtGallery {
     // ERC20 cifiTokenContract = ERC20(0xe56aB536c90E5A8f06524EA639bE9cB3589B8146);
     ERC20 cifiTokenContract = ERC20(0x89F2a5463eF4e4176E57EEf2b2fDD256Bf4bC2bD);
 
-    uint256 FEE = 100;
     uint8 cifiDecimals = cifiTokenContract.decimals();
+    uint256 FEE = 100;
     uint256 public feeAmount = FEE.mul(10**cifiDecimals).div(100);
 
     event GalleryCreated(


### PR DESCRIPTION
As you can look up in the code, nothing was changed other than the swapping of two lines of code which are one below the other

**Why it was done?**

- Usually Evm stores data in slots and each slot is maximum of 32 bytes of storage, thus if one slot filled up we get to the next one, and this obviously charges up for the gas, Thus, one must try to equip less slots in EVM if possible!!
- an `address` usually takes up 20 bytes of storage, whereas uint256 takes 32 bytes, and a bool or uint8 takes up 1 byte, For.e.g
```
// suppose this is Demo contract
contract Demo{
    address owner; // 20 bytes - slot 0
    uint256 number; // 32 bytes - slot 1
    uint8 miniNumber; // 1 byte - slot 2
```
This above snippet of code takes up 3 slots in the Evm, and as you can see in slot 0 there's some storage is left of around 12 bytes and much storage is wasted by allowing `uint8` to the slot 2

How this could be fixed? See this
```
contract Demo{
    address owner; // 20bytes - slot 0
    uint8 miniNumber; // 1 byte - slot 0, here slot 0 - 21 bytes now
    uint256 number; // 32 bytes - slot 1
```
Hence, we saved some slots from being wasted, this is what I have done in that code, if look carefully

Thanks!!